### PR TITLE
switch repo to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Using the Flathub repository
 
 To install applications that are hosted on Flathub, use the following:
 ```
-flatpak remote-add flathub http://flathub.org/repo/flathub.flatpakrepo
+flatpak remote-add flathub https://flathub.org/repo/flathub.flatpakrepo
 flatpak --user install flathub org.gnome.Recipes
 ```
 


### PR DESCRIPTION
The flathub frontend server uses HSTS and redirects every http hit to https. So, not configuring your repo as https can cause really painful performance, because the redirects can really mess up connection pooling and pipelining.